### PR TITLE
Improve DigitalOcean deployment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ make docker-deploy
 ```
 
 (Ensure Docker is installed locally, secrets are present, and ports are open)
+### Option 3: DigitalOcean Deployment
+
+Run the helper script on your Debian 12 droplet:
+```bash
+sudo ./scripts/digitalocean_setup.sh <REPO_URL> <TARGET_DIR>
+```
+This installs Docker, clones the repo, syncs the `public` submodule, and starts the Directus stack using systemd.
+---
 
 ---
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 sudo apt update && sudo apt install -y ansible
+

--- a/scripts/digitalocean_setup.sh
+++ b/scripts/digitalocean_setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Setup AthensArea stack on a Debian 12 server (e.g., DigitalOcean)
+# Usage: sudo bash digitalocean_setup.sh [REPO_URL] [TARGET_DIR]
+# Default REPO_URL is https://github.com/youruser/athensarea.git
+# Default TARGET_DIR is /opt/athensarea
+set -euo pipefail
+
+# repo to clone (defaults to your fork of this repo)
+REPO_URL=${1:-https://github.com/youruser/athensarea.git}
+# directory to clone into
+TARGET_DIR=${2:-/opt/athensarea}
+
+DEPLOY_USER=${SUDO_USER:-$(whoami)}
+
+apt-get update
+apt-get install -y git ca-certificates curl gnupg lsb-release
+
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \"$(lsb_release -cs)\" stable" \
+  | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable docker
+systemctl start docker
+
+if ! id -nG "$DEPLOY_USER" | grep -qw docker; then
+  usermod -aG docker "$DEPLOY_USER"
+fi
+
+if [ ! -d "$TARGET_DIR" ]; then
+  git clone "$REPO_URL" "$TARGET_DIR"
+fi
+cd "$TARGET_DIR"
+git pull
+git config --global --add safe.directory "$TARGET_DIR"
+git config --global --add safe.directory "$TARGET_DIR/public"
+git submodule update --init --recursive
+(cd public && git checkout production && git pull origin production || true)
+
+SERVICE_FILE=/etc/systemd/system/directus-stack.service
+install -m 644 scripts/directus-stack.service "$SERVICE_FILE"
+sed -i "s|WorkingDirectory=/vagrant|WorkingDirectory=$TARGET_DIR|" "$SERVICE_FILE"
+
+systemctl daemon-reload
+systemctl enable directus-stack.service
+systemctl restart directus-stack.service
+
+echo "✅ Deployment complete. Directus should be running."

--- a/scripts/directus-stack.service
+++ b/scripts/directus-stack.service
@@ -5,7 +5,7 @@ After=docker.service
 
 [Service]
 WorkingDirectory=/vagrant
-ExecStart=/usr/bin/docker compose up
+ExecStart=/usr/bin/docker compose up --build
 ExecStop=/usr/bin/docker compose down
 Restart=always
 RestartSec=5s


### PR DESCRIPTION
## Summary
- refine `digitalocean_setup.sh` to better mirror Vagrant environment
- update systemd service to build images
- clarify DigitalOcean section in README

## Testing
- `make lint` *(fails: ansible-lint not found)*
- `make test` *(fails: ansible-playbook not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ebd587fc832bb48be80a42ef8aa6